### PR TITLE
fix(docs): update TODO frontmatter date, use root-relative link in audit

### DIFF
--- a/docs/audits/quality-audit-2026-03.md
+++ b/docs/audits/quality-audit-2026-03.md
@@ -472,4 +472,4 @@ Each finding is tagged with:
 
 - Source files: `ralph/scripts/` (all 25 files)
 - Related: [CLI rewrite research](../research/ralph-cli-rewrite.md) (security bugs, rewrite rationale)
-- Related: [ralph/TODO.md](../../ralph/TODO.md) (backlog items from this audit)
+- Related: [ralph/TODO.md](/ralph/TODO.md) (backlog items from this audit)

--- a/ralph/TODO.md
+++ b/ralph/TODO.md
@@ -2,7 +2,7 @@
 title: Ralph TODO
 purpose: Consolidated backlog for Ralph loop — bugs, enhancements, and deferred items.
 created: 2026-03-08
-updated: 2026-03-12
+updated: 2026-03-13
 ---
 
 ## Adopt Now (zero cost)


### PR DESCRIPTION
- Update TODO.md frontmatter `updated` to 2026-03-13
- Change fragile relative link `../../ralph/TODO.md` to root-relative `/ralph/TODO.md` in audit doc

Generated with Claude <noreply@anthropic.com>