### PR TITLE
fix(docs): use root-relative link to TODO.md in CLI rewrite research

### DIFF
--- a/docs/research/ralph-cli-rewrite.md
+++ b/docs/research/ralph-cli-rewrite.md
@@ -731,12 +731,12 @@ via subprocess. They're called infrequently and work well as-is.
 
 ## Sources
 
-- [`ralph/TODO.md`](../../ralph/TODO.md) -- Consolidated backlog including rewrite item
+- [`ralph/TODO.md`](/ralph/TODO.md) -- Consolidated backlog including rewrite item
 - [Cobra](https://github.com/spf13/cobra) -- Go CLI framework
 - [Viper](https://github.com/spf13/viper) -- Go config hierarchy (TOML + env + flags)
 - [goreleaser](https://goreleaser.com/) -- Go multi-platform release automation
 - [Bun](https://bun.sh/) -- JavaScript runtime with `bun build --compile`
 - [Deno](https://deno.com/) -- TypeScript runtime with `deno compile`
 - [tree-sitter](https://github.com/tree-sitter/tree-sitter) -- Incremental parser generator (relevant for Bun/Deno signature extraction alternative)
-- [RTK](https://github.com/rtk-ai/rtk) -- Rust CLI proxy (~4.1 MB) that compresses shell command output before it reaches an LLM context window (60-90% token reduction). Intercepts commands like `git status`, `pytest`, `ruff check` via a Claude Code `PreToolUse` hook. **Complementary to Ralph**, not a replacement -- provides context compression for any `claude -p` session. Zero-cost integration via `rtk init -g` (global hook). See [TODO.md](../../ralph/TODO.md) "Adopt Now".
+- [RTK](https://github.com/rtk-ai/rtk) -- Rust CLI proxy (~4.1 MB) that compresses shell command output before it reaches an LLM context window (60-90% token reduction). Intercepts commands like `git status`, `pytest`, `ruff check` via a Claude Code `PreToolUse` hook. **Complementary to Ralph**, not a replacement -- provides context compression for any `claude -p` session. Zero-cost integration via `rtk init -g` (global hook). See [TODO.md](/ralph/TODO.md) "Adopt Now".
 - [CLI-Anything](https://github.com/HKUDS/CLI-Anything) -- Python framework that auto-generates Click-based CLIs for GUI applications (GIMP, Blender, LibreOffice) so AI agents can control them. Bridges the "agent-software gap" by analyzing a GUI app codebase, designing a CLI interface, generating tests, and publishing as a pip package. **Not applicable to Ralph** -- Ralph's tools (Claude Code, git, make) already have CLIs. Informational reference for the agent-tool interface design pattern.


### PR DESCRIPTION
Same fix as #15 — replace fragile `../../ralph/TODO.md` with root-relative `/ralph/TODO.md` (2 occurrences in Sources section).

Generated with Claude <noreply@anthropic.com>