### PR TITLE
fix: post-PR#18 test regressions and template cleanup

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -27,7 +27,7 @@ jobs:
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3
       with:
-        languages: python
+        languages: ${{ vars.CODEQL_LANGUAGES || 'python' }}
 
     - name: Autobuild
       uses: github/codeql-action/autobuild@v3

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 
 .SILENT:
 .ONESHELL:
-.PHONY: setup_scaffold setup_toolchain setup_dev setup_claude_code setup_npm_tools setup_lychee setup_project run_markdownlint lint_md lint_links ralph_validate_json ralph_create_userstory_md ralph_create_prd_md ralph_create_prd_json ralph_init_loop ralph_run ralph_worktree ralph_run_worktree ralph_init_and_run ralph_reorganize_prd ralph_status ralph_stop ralph_clean ralph_archive ralph_watch ralph_get_log vibe_start vibe_stop_all vibe_status vibe_cleanup help
+.PHONY: setup_scaffold setup_toolchain setup_dev setup_claude_code setup_npm_tools setup_lychee validate run_markdownlint lint_md lint_links ralph_validate_json ralph_create_userstory_md ralph_create_prd_md ralph_create_prd_json ralph_init_loop ralph_run ralph_worktree ralph_run_worktree ralph_init_and_run ralph_reorganize_prd ralph_status ralph_stop ralph_clean ralph_archive ralph_watch ralph_get_log vibe_start vibe_stop_all vibe_status vibe_cleanup help
 .DEFAULT_GOAL := help
 
 # Auto-include language-specific Makefile when .scaffold exists
@@ -84,8 +84,14 @@ setup_lychee:  ## Install lychee link checker (Rust binary, requires sudo)
 	curl -sL https://github.com/lycheeverse/lychee/releases/latest/download/lychee-x86_64-unknown-linux-gnu.tar.gz | sudo tar xz -C /usr/local/bin lychee
 	echo "lychee version: $$(lychee --version)"
 
-setup_project:  ## Customize template with your project details. Run with help: bash ralph/scripts/setup_project.sh help
-	bash ralph/scripts/setup_project.sh || { echo ""; echo "ERROR: Project setup failed. Please check the error messages above."; exit 1; }
+validate:  ## Run validation (delegates to scaffold adapter, no-op without scaffold)
+	if [ -f .scaffold ] && type adapter_validate >/dev/null 2>&1; then \
+		adapter_validate; \
+	elif [ -f .scaffold ]; then \
+		echo "No adapter_validate found — source ralph/scripts/lib/adapter.sh first"; \
+	else \
+		echo "No scaffold set — skipping validation (run 'make setup_scaffold LANG=<lang>' first)"; \
+	fi
 
 
 # MARK: run markdownlint

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,5 @@
+# TEMPLATE: Replace [PLACEHOLDERS] with your project values after forking.
+# Run `make setup_scaffold LANG=python && make setup_toolchain` to initialize.
 [project]
 name = "[PROJECT NAME]"
 version = "0.0.0"

--- a/ralph/scripts/tests/test_parallel_ralph.sh
+++ b/ralph/scripts/tests/test_parallel_ralph.sh
@@ -38,7 +38,7 @@ echo ""
 echo "=== Test 2: Function Definitions ==="
 TEST_COUNT=$((TEST_COUNT + 1))
 
-required_functions="create_worktree init_worktree_state start_parallel wait_and_monitor score_worktree select_best merge_best cleanup_worktrees"
+required_functions="create_worktree init_worktree_state start_parallel wait_and_monitor score_worktree select_best merge_best cleanup_on_error"
 all_found=true
 
 for func in $required_functions; do
@@ -62,7 +62,7 @@ echo ""
 echo "=== Test 3: Makefile Integration ==="
 TEST_COUNT=$((TEST_COUNT + 1))
 
-required_targets="ralph ralph_abort ralph_clean ralph_status ralph_watch ralph_get_log"
+required_targets="ralph_run ralph_stop ralph_clean ralph_status ralph_watch ralph_get_log"
 all_found=true
 
 for target in $required_targets; do
@@ -101,9 +101,9 @@ echo ""
 echo "=== Test 5: Merge Strategy Validation ==="
 TEST_COUNT=$((TEST_COUNT + 1))
 
-# Check that merge_flags variable includes --no-ff --no-commit
-if grep -q 'merge_flags="--no-ff --no-commit"' ralph/scripts/parallel_ralph.sh && \
-   grep -q 'git merge $merge_flags' ralph/scripts/parallel_ralph.sh; then
+# Check that merge_flags array includes --no-ff --no-commit
+if grep -q 'merge_flags=(--no-ff --no-commit)' ralph/scripts/parallel_ralph.sh && \
+   grep -q 'git merge "${merge_flags\[@\]}"' ralph/scripts/parallel_ralph.sh; then
     echo "✓ Merge uses correct flags (--no-ff --no-commit) with configurable options"
     PASS_COUNT=$((PASS_COUNT + 1))
 else
@@ -117,8 +117,8 @@ TEST_COUNT=$((TEST_COUNT + 1))
 
 if grep -q "score_worktree()" ralph/scripts/parallel_ralph.sh; then
     # Check for scoring components: stories, tests, validation bonus
-    if grep -A 20 "score_worktree()" ralph/scripts/parallel_ralph.sh | grep -q "stories_passed.*100"; then
-        echo "✓ Scoring algorithm includes story weight (*100)"
+    if grep -A 55 "score_worktree()" ralph/scripts/parallel_ralph.sh | grep -q "stories_passed.*10"; then
+        echo "✓ Scoring algorithm includes story weight (*10)"
         PASS_COUNT=$((PASS_COUNT + 1))
     else
         echo "✗ Scoring algorithm incomplete"
@@ -133,15 +133,17 @@ echo "=== Test 7: Cleanup Procedures ==="
 TEST_COUNT=$((TEST_COUNT + 1))
 
 cleanup_found=true
-if ! grep -q "git worktree unlock" ralph/scripts/parallel_ralph.sh; then
+# Cleanup ops live in lib/cleanup_worktrees.sh, sourced by parallel_ralph.sh
+cleanup_files="ralph/scripts/parallel_ralph.sh ralph/scripts/lib/cleanup_worktrees.sh"
+if ! grep -q "git worktree unlock" $cleanup_files; then
     echo "  ✗ Worktree unlock missing"
     cleanup_found=false
 fi
-if ! grep -q "git worktree remove" ralph/scripts/parallel_ralph.sh; then
+if ! grep -q "git worktree remove" $cleanup_files; then
     echo "  ✗ Worktree remove missing"
     cleanup_found=false
 fi
-if ! grep -q "git branch -D" ralph/scripts/parallel_ralph.sh; then
+if ! grep -q "git branch -D" $cleanup_files; then
     echo "  ✗ Branch deletion missing"
     cleanup_found=false
 fi
@@ -180,14 +182,16 @@ TEST_COUNT=$((TEST_COUNT + 1))
 
 # Test that validate_json.sh exists (executable bit may not be set until after commit)
 if [ -f "ralph/scripts/lib/validate_json.sh" ]; then
+    test_tmpdir="${TMPDIR:-/tmp}/ralph_test_$$"
+    mkdir -p "$test_tmpdir"
     # Test with valid JSON
-    echo '{"test": true}' > /tmp/test_valid.json
-    if bash ralph/scripts/lib/validate_json.sh /tmp/test_valid.json > /dev/null 2>&1; then
+    echo '{"test": true}' > "$test_tmpdir/test_valid.json"
+    if bash ralph/scripts/lib/validate_json.sh "$test_tmpdir/test_valid.json" > /dev/null 2>&1; then
         # Test with invalid JSON
-        echo '{invalid}' > /tmp/test_invalid.json
-        if ! bash ralph/scripts/lib/validate_json.sh /tmp/test_invalid.json > /dev/null 2>&1; then
+        echo '{invalid}' > "$test_tmpdir/test_invalid.json"
+        if ! bash ralph/scripts/lib/validate_json.sh "$test_tmpdir/test_invalid.json" > /dev/null 2>&1; then
             # Test with missing file
-            if ! bash ralph/scripts/lib/validate_json.sh /tmp/nonexistent.json > /dev/null 2>&1; then
+            if ! bash ralph/scripts/lib/validate_json.sh "$test_tmpdir/nonexistent.json" > /dev/null 2>&1; then
                 echo "✓ validate_json.sh works correctly (valid, invalid, missing)"
                 PASS_COUNT=$((PASS_COUNT + 1))
             else
@@ -199,7 +203,7 @@ if [ -f "ralph/scripts/lib/validate_json.sh" ]; then
     else
         echo "✗ validate_json.sh rejects valid JSON"
     fi
-    rm -f /tmp/test_valid.json /tmp/test_invalid.json
+    rm -rf "$test_tmpdir"
 else
     echo "✗ validate_json.sh missing or not executable"
 fi


### PR DESCRIPTION
## Summary

- Fix 6 failing test assertions in `test_parallel_ralph.sh` caused by PR #18 refactoring
- Add base `validate` target to Makefile (adapter fallback for scaffold system)
- Remove stale `setup_project` recipe (script removed in PR #18)
- Parameterize `codeql.yaml` language via `vars.CODEQL_LANGUAGES` repository variable
- Add template placeholder comment to `pyproject.toml`

## Test plan

- [ ] `bash ralph/scripts/tests/test_parallel_ralph.sh` — Tests 1-8, 10 pass (Test 9 requires writable `/tmp`)
- [ ] `make validate` — runs without error when no `.scaffold` is set
- [ ] `codeql.yaml` uses `${{ vars.CODEQL_LANGUAGES || 'python' }}` (defaults to python if unset)

Generated with Claude <noreply@anthropic.com>