### PR TITLE
chore: standardize repo scaffold

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "attribution": {
+    "commit": "Co-Authored-By: Claude <noreply@anthropic.com>",
+    "pr": "Generated with Claude <noreply@anthropic.com>"
+  },
+  "enabledPlugins": {
+    "commit-helper@qte77-claude-code-utils": true
+  },
+  "extraKnownMarketplaces": {
+    "qte77-claude-code-utils": {
+      "source": {
+        "source": "github",
+        "repo": "qte77/claude-code-utils-plugin"
+      }
+    }
+  }
+}

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug report
+about: Report a problem
+title: ''
+labels: bug
+assignees: ''
+---
+
+## Description
+
+<!-- A clear and concise description of the bug -->
+
+## Steps to Reproduce
+
+1. Run `...`
+2. ...
+
+## Expected Behavior
+
+<!-- What you expected to happen -->
+
+## Actual Behavior
+
+<!-- What actually happened. Include error traces if applicable -->
+
+## Environment
+
+- OS/Runner:
+- Version:
+
+## Additional Context
+
+<!-- Screenshots, logs, related issues, etc. -->

--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,15 @@
+---
+name: Question
+about: Ask a question not covered by the documentation
+title: ''
+labels: question
+assignees: ''
+---
+
+**Have you checked the docs?**
+
+- [ ] README.md
+
+## Question
+
+<!-- Your question here -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,37 @@
+# Summary
+
+<!-- Brief description of what this PR does and why -->
+
+Closes <!-- #issue-number or N/A -->
+
+## Type of Change
+
+<!-- Check all that apply. Commit type must match conventional commits: feat|fix|build|chore|ci|docs|style|refactor|perf|revert|test -->
+
+- [ ] `feat` — new feature
+- [ ] `fix` — bug fix
+- [ ] `docs` — documentation only
+- [ ] `refactor` — no functional change
+- [ ] `test` — test additions or fixes
+- [ ] `ci` — CI/CD changes
+- [ ] `build` — build system or dependency changes
+- [ ] `perf` — performance improvement
+- [ ] `style` — formatting, whitespace (no logic change)
+- [ ] `revert` — reverts a previous commit
+- [ ] `chore` — tooling, config, maintenance
+- [ ] **Breaking change** — add `!` after commit type
+
+## Self-Review
+
+- [ ] I have reviewed my own diff and removed debug/dead code
+- [ ] Commit messages follow conventional commits format
+
+## Testing
+
+- [ ] Tests pass locally
+- [ ] CI workflows pass
+
+## Security
+
+- [ ] No hardcoded secrets, API keys, or credentials
+- [ ] No new injection vectors in workflow `run:` steps

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,11 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary

Standardize repository scaffold to match the qte77 org-wide pattern.

## Changes

- `.gitmessage` — conventional commits template
- `.claude/settings.json` — attribution config + commit-helper plugin
- `SECURITY.md` — GitHub Security Advisories reporting link
- `.github/PULL_REQUEST_TEMPLATE.md` — conventional commits PR checklist
- `.github/ISSUE_TEMPLATE/` — bug report + question templates
- CodeQL workflow (where applicable)
- Dependabot config (where applicable)
- `LICENSE` (BSD-3-Clause, where missing)
- `.gitignore` (where missing / fixed)

Generated with Claude <noreply@anthropic.com>

Closes #38