### PR TITLE
chore: rename repo references to claude-code-plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Supported languages:
 | `embedded` | cmake, C compiler | cmake build |
 
 Language-specific Claude Code skills are **not** checked into the template.
-Install them from [claude-code-utils-plugin](https://github.com/qte77/claude-code-utils-plugin)
+Install them from [claude-code-plugins](https://github.com/qte77/claude-code-plugins)
 as needed for your language.
 
 ## Quick Start

--- a/TODO.md
+++ b/TODO.md
@@ -5,7 +5,7 @@ updated: 2026-03-13
 status: in-progress
 target_repos:
   - qte77/ralph-loop-cc-tdd-wt-vibe-kanban-template
-  - qte77/claude-code-utils-plugin
+  - qte77/claude-code-plugins
 phases: 8
 ---
 


### PR DESCRIPTION
## Summary
- Rename `claude-code-utils-plugin` → `claude-code-plugins` in TODO.md and README.md

Follows GitHub repo rename qte77/claude-code-utils-plugin → qte77/claude-code-plugins.

🤖 Generated with Claude <noreply@anthropic.com>