### PR TITLE
ci: adopt qte77 codeql+dependabot baseline

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+---
+# https://docs.github.com/code-security/dependabot/working-with-dependabot/dependabot-options-reference
+#
+# Two ecosystems:
+# - "uv" parses pyproject.toml + uv.lock (the dependabot pip ecosystem would
+#   be a no-op here since this repo is uv-managed, not requirements.txt-based).
+# - "github-actions" keeps SHA-pinned action references in .github/workflows/
+#   up to date. Repo rule requires full commit SHA pins.
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"
+      - "python"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(ci)"
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,12 +1,9 @@
 ---
-# https://github.blog/changelog/2023-01-18-code-scanning-codeql-action-v1-is-now-deprecated/
+# https://github.blog/changelog/2025-10-28-upcoming-deprecation-of-codeql-action-v3/
 name: "CodeQL"
 
 on:
   push:
-  pull_request:
-    types: [closed]
-    branches: [ main ]
   schedule:
     - cron: '27 11 * * 0'
   workflow_dispatch:
@@ -22,22 +19,26 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225  # v4
       with:
         languages: ${{ vars.CODEQL_LANGUAGES || 'python' }}
 
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
-    # if autobuild fails
-    #- run: |
-    #   make bootstrap
-    #   make release
+      uses: github/codeql-action/autobuild@95e58e9a2cdfd71adc6e0353d5c52f41a045d225  # v4
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
-    #- name: sarif
-    #  uses: github/codeql-action/upload-sarif@v2
-...
+      id: analyze
+      uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225  # v4
+      with:
+        output: sarif-results
+
+    - name: Dismiss alerts with inline suppression comments
+      uses: advanced-security/dismiss-alerts@046d6b48d2e43cf563f96f67332c47c432eff83e  # v2.0.2
+      with:
+        sarif-id: ${{ steps.analyze.outputs.sarif-id }}
+        sarif-file: sarif-results
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Adopts the qte77 "newer-style" CodeQL + Dependabot baseline.

**CodeQL changes** (`.github/workflows/codeql.yaml`):
- Bump CodeQL Action **v3 → v4** (v3 deprecated 2025-10-28)
- **Remove `pull_request` trigger** — its merge-ref SHA races GitHub's merge-protection check
- **SHA-pin every `uses:`** per repo rule (no floating tags)
- Add `id: analyze` + `output: sarif-results` and the **`advanced-security/dismiss-alerts`** step so inline `// codeql[...]` suppressions actually dismiss alerts
- Preserve template parameterization: `languages: ${{ vars.CODEQL_LANGUAGES || 'python' }}`

**Dependabot changes** (`.github/dependabot.yml`, new file):
- `package-ecosystem: "uv"` (this repo ships `uv.lock`; pip ecosystem would no-op)
- `package-ecosystem: "github-actions"` to keep SHA pins current

## Exemplars

- CodeQL gold: `qte77/doc-pipeline-engine` (SHA-pinned variant)
- Dependabot gold: `qte77/analyze-stock-kpi`

## Test plan

- [ ] CodeQL workflow runs successfully on push
- [ ] Dependabot opens PRs for stale `uv` and `github-actions` deps
- [ ] No `pull_request` race with merge protection observed
- [ ] Inline suppression comments dismiss alerts (smoke-test once an alert exists)
