### PR TITLE
feat(scaffold): add LANG=typescript adapter (eslint + tsc + vitest)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,15 +15,15 @@
 # MARK: scaffold
 
 
-setup_scaffold:  ## Initialize scaffold for a language. Usage: make setup_scaffold LANG=python|embedded
+setup_scaffold:  ## Initialize scaffold for a language. Usage: make setup_scaffold LANG=python|embedded|typescript
 	if [ -z "$(LANG)" ]; then
-		echo "ERROR: LANG is required. Usage: make setup_scaffold LANG=python|embedded"
+		echo "ERROR: LANG is required. Usage: make setup_scaffold LANG=python|embedded|typescript"
 		exit 1
 	fi
 	case "$(LANG)" in
-		python|embedded) ;;
+		python|embedded|typescript) ;;
 		*)
-			echo "ERROR: Unsupported LANG '$(LANG)'. Supported: python, embedded"
+			echo "ERROR: Unsupported LANG '$(LANG)'. Supported: python, embedded, typescript"
 			exit 1
 		;;
 	esac
@@ -52,6 +52,20 @@ setup_toolchain:  ## Install toolchain for the active scaffold (reads .scaffold)
 				exit 1
 			fi
 			echo "Embedded toolchain ready (cmake: $$(cmake --version | head -1))"
+		;;
+		typescript)
+			if ! command -v node > /dev/null 2>&1; then
+				echo "ERROR: node not found — install Node.js first"
+				exit 1
+			fi
+			if [ ! -f package.json ]; then
+				echo "ERROR: package.json not found — run 'npm init' first"
+				exit 1
+			fi
+			npm install
+			$(MAKE) -s setup_npm_tools
+			$(MAKE) -s setup_lychee
+			echo "TypeScript toolchain ready (node: $$(node --version))"
 		;;
 		*)
 			echo "ERROR: Unknown language '$$LANG' in .scaffold"

--- a/Makefile.typescript
+++ b/Makefile.typescript
@@ -1,0 +1,61 @@
+# TypeScript-specific Makefile recipes.
+# Auto-included by main Makefile when .scaffold contains 'typescript'.
+# Run `make help` for available recipes.
+
+.PHONY: lint type_check duplication lint_hardcoded_paths test_all test_quick test_coverage validate validate_quick quick_validate
+
+# MARK: typescript sanity
+
+lint:  ## Lint: ESLint with --fix
+	npm exec eslint -- --fix .
+
+type_check:  ## Static type checking with tsc
+	npm exec tsc -- --noEmit
+
+duplication:  ## Check for code duplication with jscpd
+	jscpd src/ --reporters console --format typescript
+
+lint_hardcoded_paths:  ## GHA safety: check for /workspaces/ in test files
+	echo "Checking for hardcoded /workspaces/ paths in tests..."
+	if grep -rn --include='*.ts' --include='*.tsx' '/workspaces/' tests/ 2>/dev/null; then
+		echo "ERROR: Found hardcoded /workspaces/ paths in tests (breaks GHA)"
+		exit 1
+	fi
+	echo "No hardcoded paths found"
+
+# MARK: typescript test
+
+test_all:  ## Run all tests with vitest
+	npm exec vitest -- run
+
+test_quick:  ## Quick test - bail on first failure (use during fix iterations)
+	npm exec vitest -- run --bail 1
+
+test_coverage:  ## Run tests with coverage threshold (configure in vitest.config)
+	echo "Running tests with coverage gate (configure thresholds in vitest.config)..."
+	npm exec vitest -- run --coverage
+
+# MARK: typescript validate
+
+validate:  ## Complete pre-commit validation sequence
+	set -e
+	echo "Running complete validation sequence..."
+	$(MAKE) -s lint
+	$(MAKE) -s type_check
+	$(MAKE) -s test_coverage
+	echo "Validation completed successfully"
+
+validate_quick:  ## Quick validation for fix iterations (no coverage check)
+	set -e
+	echo "Running quick validation (no coverage check)..."
+	$(MAKE) -s lint
+	$(MAKE) -s type_check
+	$(MAKE) -s test_quick
+	echo "Quick validation completed"
+
+quick_validate:  ## Fast development cycle validation
+	echo "Running quick validation ..."
+	$(MAKE) -s lint
+	-$(MAKE) -s type_check
+	-$(MAKE) -s lint_hardcoded_paths
+	echo "Quick validation completed (check output for any failures)"

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Supported languages:
 |--------|-----------|---------|
 | `python` | uv, ruff, pyright, pytest | ruff + pyright + complexipy + pytest |
 | `embedded` | cmake, C compiler | cmake build |
+| `typescript` | node, npm, eslint, tsc, vitest | eslint + tsc + vitest |
 
 Language-specific Claude Code skills are **not** checked into the template.
 Install them from [claude-code-plugins](https://github.com/qte77/claude-code-plugins)


### PR DESCRIPTION
## Summary

Adds `LANG=typescript` to the template's plugin-based scaffold system. This is **Slice 1** of the polyglot-scaffold extension — driven by real demand (`agenthud-agui-a2ui` is the qte77 org's only existing TypeScript repo and would benefit from the ralph loop).

YAGNI-correct scope:
- **In** — `typescript` (1 real consumer today)
- **Out** — `rust`, `go`, `cpp` (no source consumers yet; defer until `ralph-cli` or a new project actually needs them)

## Changes

**`Makefile`** — extends both scaffold entry points:
- `setup_scaffold` case accepts `typescript`; help/error text updated
- `setup_toolchain` adds a `typescript)` branch: checks `node` + `package.json`, runs `npm install`, also installs shared `npm_tools` + `lychee`

**`Makefile.typescript`** (new) — implements the same recipe contract as `Makefile.python`/`Makefile.embedded`:
- `lint` → `eslint --fix .`
- `type_check` → `tsc --noEmit`
- `duplication` → `jscpd src/ --format typescript`
- `lint_hardcoded_paths` → grep `*.ts`/`*.tsx` under `tests/` for `/workspaces/`
- `test_all` / `test_quick` / `test_coverage` → `vitest run` (with `--bail 1` and `--coverage` variants)
- `validate` → lint + type_check + test_coverage
- `validate_quick` → lint + type_check + test_quick (no coverage)
- `quick_validate` → lint + soft type_check + soft path check

Intentionally omitted vs `Makefile.python`:
- `complexity` (no direct `complexipy` equivalent; can be added later via `eslint-plugin-complexity` if needed)
- `docs_serve` / `docs_build` (TS projects bring their own — typedoc, docusaurus, etc.)

**`README.md`** — adds a row to the supported-languages table.

## Test plan

- [ ] `make setup_scaffold LANG=typescript` writes `typescript` to `.scaffold`
- [ ] `make setup_toolchain` errors clearly if `node` or `package.json` is missing
- [ ] `make setup_toolchain` runs `npm install` and reports the node version
- [ ] `make lint` / `type_check` / `test_all` work in a TS project with eslint/tsc/vitest configured
- [ ] `make validate` runs the full chain end-to-end
- [ ] Existing `LANG=python` and `LANG=embedded` paths still work (no regression)

## Followups (not in this PR)

- `Makefile.rust` when `ralph-cli` is ready to build
- `Makefile.go` / `Makefile.cpp` when a project actually needs them
- Optional `complexity` recipe via an eslint plugin if cognitive-complexity gating is wanted
