### PR TITLE
chore(lint): disable MD013 line-length for local/CI parity

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,3 +1,6 @@
 {
+  "config": {
+    "MD013": false
+  },
   "ignores": ["ralph/**"]
 }


### PR DESCRIPTION
Disable MD013 (line-length) in `.markdownlint-cli2.jsonc` so local `make lint_md` matches CI (which fetches qte77/.github's relaxed shared config). Tooling config only; no code; CI behaviour unchanged. Per request to exclude MD013/line-length.

Generated with Claude <noreply@anthropic.com>