### PR TITLE
refactor(prd): strict-TDD extraction of generate_prd_json helpers

### DIFF
--- a/ralph/scripts/generate_prd_json.py
+++ b/ralph/scripts/generate_prd_json.py
@@ -473,6 +473,42 @@ def _resolve_acceptance_and_files(
     return feature["acceptance"], feature["files"]
 
 
+def _lookup_feature(
+    spec: StorySpec, features: dict[str, Feature]
+) -> tuple[Feature | None, str | None]:
+    """Resolve a spec's feature, handling dotted IDs (e.g. "11.1" -> parent "11").
+
+    Returns:
+        Tuple of (feature_or_None, sub_number_or_None).
+    """
+    feature = features.get(spec["feature_id"])
+    # Reason: Dotted IDs like "11.1" reference sub-features under parent "11"
+    if not feature and "." in spec["feature_id"]:
+        parent_id, _ = spec["feature_id"].split(".", 1)
+        return features.get(parent_id), spec["feature_id"]
+    return feature, None
+
+
+def _resolve_sub_or_fallback(
+    spec: StorySpec,
+    feature: Feature,
+    specs: list[StorySpec],
+    sub_number: str | None,
+) -> tuple[list[str], list[str]]:
+    """Resolve acceptance/files, preferring an exact sub-feature number match.
+
+    For dotted IDs, match the specific sub-feature by number; otherwise (or on
+    no match) fall back to label/merge resolution.
+    """
+    if sub_number:
+        sub_features: dict[str, SubFeature] | None = feature.get("sub_features")  # type: ignore[typeddict-item]
+        if sub_features:
+            for sf_data in sub_features.values():
+                if sf_data["number"] == sub_number:
+                    return sf_data["acceptance"], sf_data["files"]
+    return _resolve_acceptance_and_files(spec, feature, specs)
+
+
 def resolve_stories(specs: list[StorySpec], features: dict[str, Feature]) -> list[Story]:
     """Resolve story specs into complete Story objects using feature data.
 
@@ -486,32 +522,12 @@ def resolve_stories(specs: list[StorySpec], features: dict[str, Feature]) -> lis
     stories: list[Story] = []
 
     for spec in specs:
-        feature = features.get(spec["feature_id"])
-        # Reason: Dotted IDs like "11.1" reference sub-features under parent "11"
-        sub_number: str | None = None
-        if not feature and "." in spec["feature_id"]:
-            parent_id, _ = spec["feature_id"].split(".", 1)
-            feature = features.get(parent_id)
-            sub_number = spec["feature_id"]
+        feature, sub_number = _lookup_feature(spec, features)
         if not feature:
             print(f"Warning: Feature {spec['feature_id']} not found for {spec['id']}")
             continue
 
-        # Reason: When breakdown uses dotted ID, match the specific sub-feature
-        # by number instead of relying on label-based fuzzy matching
-        if sub_number:
-            sub_features: dict[str, SubFeature] | None = feature.get("sub_features")  # type: ignore[typeddict-item]
-            if sub_features:
-                for _, sf_data in sub_features.items():
-                    if sf_data["number"] == sub_number:
-                        acceptance, files = sf_data["acceptance"], sf_data["files"]
-                        break
-                else:
-                    acceptance, files = _resolve_acceptance_and_files(spec, feature, specs)
-            else:
-                acceptance, files = _resolve_acceptance_and_files(spec, feature, specs)
-        else:
-            acceptance, files = _resolve_acceptance_and_files(spec, feature, specs)
+        acceptance, files = _resolve_sub_or_fallback(spec, feature, specs, sub_number)
         description = feature["description"]
 
         stories.append(
@@ -532,11 +548,38 @@ def resolve_stories(specs: list[StorySpec], features: dict[str, Feature]) -> lis
     return stories
 
 
+def _migrate_legacy_passes(story: Story) -> bool:
+    """Migrate legacy ``passes: bool`` to ``status: str``. Returns True if changed."""
+    # Reason: Migrate legacy `passes: bool` -> `status: str`
+    if "passes" in story and "status" not in story:
+        story["status"] = "passed" if story["passes"] else "pending"  # type: ignore[typeddict-item]
+        del story["passes"]  # type: ignore[typeddict-item]
+        return True
+    return False
+
+
+def _fill_missing_fields(story: Story) -> bool:
+    """Add content_hash/depends_on/status to an incomplete story. Returns True if changed."""
+    modified = False
+    if "content_hash" not in story:
+        story["content_hash"] = compute_hash(
+            story["title"], story["description"], story["acceptance"]
+        )
+        modified = True
+    if "depends_on" not in story:
+        story["depends_on"] = []
+        modified = True
+    if "status" not in story:
+        story["status"] = "pending"
+        modified = True
+    return modified
+
+
 def _backfill_existing_stories(existing_stories: list[Story]) -> tuple[int, int]:
     """Backfill missing fields and migrate legacy schema on existing stories.
 
     Handles migration from legacy ``passes: bool`` to ``status: str`` enum,
-    and adds ``wave: int`` field when missing.
+    and adds ``wave: int`` field when missing. Mutates stories in place.
 
     Args:
         existing_stories: List of existing story dicts (mutated in place).
@@ -547,34 +590,20 @@ def _backfill_existing_stories(existing_stories: list[Story]) -> tuple[int, int]
     passed_count = 0
     updated_count = 0
     for story in existing_stories:
-        modified = False
-
-        # Reason: Migrate legacy `passes: bool` -> `status: str`
-        if "passes" in story and "status" not in story:
-            story["status"] = "passed" if story["passes"] else "pending"  # type: ignore[typeddict-item]
-            del story["passes"]  # type: ignore[typeddict-item]
-            modified = True
+        modified = _migrate_legacy_passes(story)
 
         if "wave" not in story:
             story["wave"] = 0
             modified = True
 
+        # Reason: passed stories are protected — never add/overwrite their fields
         if story.get("status") == "passed":
             passed_count += 1
             if modified:
                 updated_count += 1
             continue
 
-        if "content_hash" not in story:
-            story["content_hash"] = compute_hash(
-                story["title"], story["description"], story["acceptance"]
-            )
-            modified = True
-        if "depends_on" not in story:
-            story["depends_on"] = []
-            modified = True
-        if "status" not in story:
-            story["status"] = "pending"
+        if _fill_missing_fields(story):
             modified = True
         if modified:
             updated_count += 1
@@ -715,6 +744,39 @@ def _print_summary(output_path: Path, all_stories: list[Story]) -> None:
             print(f"  Wave {wave_num}: {', '.join(waves[wave_num])}")
 
 
+def _check_declared_story_count(prd_content: str, parsed_count: int) -> None:
+    """Warn if the PRD's declared story count differs from the parsed count."""
+    # Reason: Cross-check declared story count against parsed count
+    declared_match = re.search(r"Story Breakdown[^\n]*\((\d+) stories", prd_content)
+    if declared_match:
+        declared = int(declared_match.group(1))
+        if declared != parsed_count:
+            print(f"WARNING: PRD declares {declared} stories but parser found {parsed_count}")
+
+
+def _write_prd_json(
+    output_path: Path,
+    project_name: str,
+    description: str,
+    source_name: str,
+    all_stories: list[Story],
+) -> None:
+    """Write the prd.json document to disk (creates parent directories)."""
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "w") as f:
+        json.dump(
+            {
+                "project": project_name,
+                "description": description,
+                "source": source_name,
+                "generated": datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S"),
+                "stories": all_stories,
+            },
+            f,
+            indent=2,
+        )
+
+
 def main() -> int:
     """Parse PRD markdown and generate ralph/docs/prd.json.
 
@@ -753,12 +815,7 @@ def main() -> int:
     specs = parse_story_breakdown(prd_content)
     print(f"Found {len(specs)} story specs")
 
-    # Reason: Cross-check declared story count against parsed count
-    declared_match = re.search(r"Story Breakdown[^\n]*\((\d+) stories", prd_content)
-    if declared_match:
-        declared = int(declared_match.group(1))
-        if declared != len(specs):
-            print(f"WARNING: PRD declares {declared} stories but parser found {len(specs)}")
+    _check_declared_story_count(prd_content, len(specs))
 
     print("Resolving stories...")
     new_parsed_stories = resolve_stories(specs, features)
@@ -773,19 +830,7 @@ def main() -> int:
     all_stories = _merge_with_existing(output_path, new_parsed_stories)
     compute_waves(all_stories)
 
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(output_path, "w") as f:
-        json.dump(
-            {
-                "project": project_name,
-                "description": description,
-                "source": prd_path.name,
-                "generated": datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S"),
-                "stories": all_stories,
-            },
-            f,
-            indent=2,
-        )
+    _write_prd_json(output_path, project_name, description, prd_path.name, all_stories)
 
     _print_summary(output_path, all_stories)
     return 0

--- a/ralph/scripts/tests/test_generate_prd_json.py
+++ b/ralph/scripts/tests/test_generate_prd_json.py
@@ -1,0 +1,244 @@
+"""Characterization tests for generate_prd_json.
+
+These pin the CURRENT behavior of the pure parsing/resolution functions so the
+upcoming behavior-preserving refactor can be verified against a green baseline.
+They import the script module directly (it is stdlib-only) and do not touch any
+existing test files.
+
+Run (template pyproject has placeholders, so use an isolated env):
+  uv run --no-project --with pytest pytest ralph/scripts/tests/test_generate_prd_json.py -q
+"""
+
+import sys
+from pathlib import Path
+
+# generate_prd_json.py lives one level up from this tests/ dir.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import generate_prd_json as g  # noqa: E402
+
+
+# --- Fixture PRD -----------------------------------------------------------
+
+PRD = """\
+---
+title: PRD for **DemoProj**
+description: A demo project.
+version: 1.0
+---
+
+## Features
+
+#### Feature 1: Core Engine
+
+**Description**: The core engine feature.
+
+**Acceptance Criteria**:
+
+- [ ] Engine starts
+- [ ] Engine stops
+
+**Files**:
+
+- `src/engine.py`
+
+#### Feature 2: Storage
+
+**Description**: Storage subsystem.
+
+**Acceptance Criteria**:
+
+- [ ] Saves data
+
+**Files**:
+
+- `src/storage.py`
+
+##### 2.1 Cache Layer
+
+**Acceptance Criteria**:
+
+- [ ] Cache hits
+
+**Files**:
+
+- `src/cache.py`
+
+##### 2.2 Disk Layer
+
+**Acceptance Criteria**:
+
+- [ ] Disk writes
+
+**Files**:
+
+- `src/disk.py`
+
+## Notes for Ralph Loop
+
+### Story Breakdown (3 stories):
+
+- **Feature 1** → STORY-001: Build engine
+- **Feature 2 (Cache Layer)** → STORY-002: Add cache (depends: STORY-001)
+- **Feature 2.1** → STORY-003: Cache detail
+"""
+
+
+# --- Pure helpers ----------------------------------------------------------
+
+def test_compute_hash_is_deterministic_64_hex():
+    h1 = g.compute_hash("t", "d", ["a", "b"])
+    h2 = g.compute_hash("t", "d", ["a", "b"])
+    assert h1 == h2
+    assert len(h1) == 64
+    assert all(c in "0123456789abcdef" for c in h1)
+
+
+def test_compute_hash_changes_with_content():
+    assert g.compute_hash("t", "d", ["a"]) != g.compute_hash("t", "d", ["b"])
+
+
+def test_story_sort_key():
+    assert g.story_sort_key("STORY-003") == (3, "")
+    assert g.story_sort_key("STORY-010b") == (10, "b")
+    assert g.story_sort_key("STORY-010") < g.story_sort_key("STORY-010b")
+
+
+def test_extract_project_name_variants():
+    assert g.extract_project_name({"title": "PRD for **DemoProj**"}) == "DemoProj"
+    assert g.extract_project_name({"title": "Plan for MyThing"}) == "MyThing"
+    assert g.extract_project_name({"title": "Just A Title"}) == "Just A Title"
+    assert g.extract_project_name({}) == "Unknown Project"
+
+
+def test_parse_frontmatter():
+    fm = g.parse_frontmatter(PRD)
+    assert fm["description"] == "A demo project."
+    assert fm["version"] == "1.0"
+
+
+def test_parse_depends():
+    assert g._parse_depends("STORY-001, STORY-002b") == ["STORY-001", "STORY-002b"]
+    assert g._parse_depends(None) == []
+    assert g._parse_depends("") == []
+
+
+# --- Feature parsing -------------------------------------------------------
+
+def test_parse_features_with_subfeatures():
+    feats = g.parse_features(PRD)
+    assert set(feats.keys()) == {"1", "2"}
+    assert feats["1"]["name"] == "Core Engine"
+    assert "Engine starts" in feats["1"]["acceptance"]
+    assert feats["1"]["files"] == ["src/engine.py"]
+    subs = feats["2"].get("sub_features")
+    assert subs is not None
+    assert {s["number"] for s in subs.values()} == {"2.1", "2.2"}
+
+
+# --- Story breakdown + resolution ------------------------------------------
+
+def test_parse_story_breakdown_specs():
+    specs = g.parse_story_breakdown(PRD)
+    ids = [s["id"] for s in specs]
+    assert ids == ["STORY-001", "STORY-002", "STORY-003"]
+    s2 = next(s for s in specs if s["id"] == "STORY-002")
+    assert s2["label"] == "Cache Layer"
+    assert s2["depends_on"] == ["STORY-001"]
+    s3 = next(s for s in specs if s["id"] == "STORY-003")
+    assert s3["feature_id"] == "2.1"
+
+
+def test_resolve_stories_dotted_subfeature_and_merge():
+    specs = g.parse_story_breakdown(PRD)
+    feats = g.parse_features(PRD)
+    stories = g.resolve_stories(specs, feats)
+    by_id = {s["id"]: s for s in stories}
+
+    # STORY-003 uses dotted ID -> exact sub-feature 2.1 (Cache Layer)
+    assert by_id["STORY-003"]["acceptance"] == ["Cache hits"]
+    assert by_id["STORY-003"]["files"] == ["src/cache.py"]
+
+    # STORY-002 is the only non-dotted story on feature 2 -> merges all sub-features
+    assert "Saves data" in by_id["STORY-002"]["acceptance"]
+    assert "Cache hits" in by_id["STORY-002"]["acceptance"]
+    assert "Disk writes" in by_id["STORY-002"]["acceptance"]
+
+    # STORY-001 -> feature-level data
+    assert by_id["STORY-001"]["acceptance"] == ["Engine starts", "Engine stops"]
+    assert by_id["STORY-001"]["depends_on"] == []
+    assert by_id["STORY-001"]["content_hash"]
+
+
+# --- Waves -----------------------------------------------------------------
+
+def test_compute_waves_linear():
+    specs = g.parse_story_breakdown(PRD)
+    feats = g.parse_features(PRD)
+    stories = g.resolve_stories(specs, feats)
+    g.compute_waves(stories)
+    by_id = {s["id"]: s for s in stories}
+    assert by_id["STORY-001"]["wave"] == 1
+    assert by_id["STORY-003"]["wave"] == 1
+    assert by_id["STORY-002"]["wave"] == 2  # depends on STORY-001
+
+
+def test_compute_waves_circular_falls_back_to_zero():
+    a: g.Story = {
+        "id": "STORY-001", "title": "a", "description": "", "acceptance": [],
+        "files": [], "status": "pending", "wave": 0, "completed_at": None,
+        "content_hash": "x", "depends_on": ["STORY-002"],
+    }
+    b: g.Story = {
+        "id": "STORY-002", "title": "b", "description": "", "acceptance": [],
+        "files": [], "status": "pending", "wave": 0, "completed_at": None,
+        "content_hash": "y", "depends_on": ["STORY-001"],
+    }
+    g.compute_waves([a, b])
+    assert a["wave"] == 0
+    assert b["wave"] == 0
+
+
+def test_compute_waves_passed_story_is_wave_zero():
+    done: g.Story = {
+        "id": "STORY-001", "title": "a", "description": "", "acceptance": [],
+        "files": [], "status": "passed", "wave": 5, "completed_at": "t",
+        "content_hash": "x", "depends_on": [],
+    }
+    nxt: g.Story = {
+        "id": "STORY-002", "title": "b", "description": "", "acceptance": [],
+        "files": [], "status": "pending", "wave": 0, "completed_at": None,
+        "content_hash": "y", "depends_on": ["STORY-001"],
+    }
+    g.compute_waves([done, nxt])
+    assert done["wave"] == 0
+    assert nxt["wave"] == 1  # dep already passed/placed
+
+
+# --- Backfill / migration --------------------------------------------------
+
+def test_backfill_migrates_legacy_passes_to_status():
+    stories = [{"id": "STORY-001", "title": "t", "description": "d",
+                "acceptance": [], "passes": True}]
+    passed, updated = g._backfill_existing_stories(stories)  # type: ignore[arg-type]
+    assert stories[0]["status"] == "passed"
+    assert "passes" not in stories[0]
+    assert passed == 1
+
+
+def test_backfill_protects_passed_story_fields():
+    # A passed story missing content_hash is NOT given one (protected/short-circuit).
+    stories = [{"id": "STORY-001", "title": "t", "description": "d",
+                "acceptance": [], "status": "passed"}]
+    g._backfill_existing_stories(stories)  # type: ignore[arg-type]
+    assert "content_hash" not in stories[0]
+
+
+def test_backfill_fills_missing_fields_on_incomplete():
+    stories = [{"id": "STORY-001", "title": "t", "description": "d",
+                "acceptance": ["x"], "status": "pending"}]
+    _, updated = g._backfill_existing_stories(stories)  # type: ignore[arg-type]
+    assert stories[0]["content_hash"]
+    assert stories[0]["depends_on"] == []
+    assert stories[0]["wave"] == 0
+    assert updated == 1

--- a/ralph/scripts/tests/test_generate_prd_json.py
+++ b/ralph/scripts/tests/test_generate_prd_json.py
@@ -242,3 +242,75 @@ def test_backfill_fills_missing_fields_on_incomplete():
     assert stories[0]["depends_on"] == []
     assert stories[0]["wave"] == 0
     assert updated == 1
+
+
+# --- Unit tests for the newly extracted helpers ----------------------------
+
+def test_lookup_feature_direct_dotted_missing():
+    feats = g.parse_features(PRD)
+    direct = {"id": "S", "title": "t", "feature_id": "1", "label": "", "depends_on": []}
+    f, sub = g._lookup_feature(direct, feats)  # type: ignore[arg-type]
+    assert f is feats["1"] and sub is None
+
+    dotted = {"id": "S", "title": "t", "feature_id": "2.1", "label": "", "depends_on": []}
+    f2, sub2 = g._lookup_feature(dotted, feats)  # type: ignore[arg-type]
+    assert f2 is feats["2"] and sub2 == "2.1"
+
+    missing = {"id": "S", "title": "t", "feature_id": "99", "label": "", "depends_on": []}
+    f3, sub3 = g._lookup_feature(missing, feats)  # type: ignore[arg-type]
+    assert f3 is None and sub3 is None
+
+
+def test_resolve_sub_or_fallback_exact_and_fallback():
+    feats = g.parse_features(PRD)
+    feature2 = feats["2"]
+    spec = {"id": "S", "title": "t", "feature_id": "2", "label": "", "depends_on": []}
+    acc, files = g._resolve_sub_or_fallback(spec, feature2, [spec], "2.1")  # type: ignore[arg-type]
+    assert acc == ["Cache hits"] and files == ["src/cache.py"]
+    # No sub_number -> fallback; single story on feature 2 merges all sub-features.
+    acc2, _ = g._resolve_sub_or_fallback(spec, feature2, [spec], None)  # type: ignore[arg-type]
+    assert "Saves data" in acc2
+
+
+def test_migrate_legacy_passes():
+    s = {"id": "X", "passes": True}
+    assert g._migrate_legacy_passes(s) is True  # type: ignore[arg-type]
+    assert s["status"] == "passed" and "passes" not in s
+
+    s2 = {"id": "X", "passes": False}
+    assert g._migrate_legacy_passes(s2) is True  # type: ignore[arg-type]
+    assert s2["status"] == "pending"
+
+    # status already present -> no migration
+    s3 = {"id": "X", "status": "pending", "passes": True}
+    assert g._migrate_legacy_passes(s3) is False  # type: ignore[arg-type]
+    assert g._migrate_legacy_passes({"id": "X"}) is False  # type: ignore[arg-type]
+
+
+def test_fill_missing_fields_is_idempotent():
+    s = {"id": "X", "title": "t", "description": "d", "acceptance": ["a"]}
+    assert g._fill_missing_fields(s) is True  # type: ignore[arg-type]
+    assert s["content_hash"] and s["depends_on"] == [] and s["status"] == "pending"
+    assert g._fill_missing_fields(s) is False  # type: ignore[arg-type]
+
+
+def test_check_declared_story_count_warns(capsys):
+    g._check_declared_story_count("Story Breakdown (3 stories):", 2)
+    out = capsys.readouterr().out
+    assert "WARNING" in out and "3" in out and "2" in out
+    g._check_declared_story_count("Story Breakdown (3 stories):", 3)
+    assert "WARNING" not in capsys.readouterr().out
+
+
+def test_write_prd_json_roundtrip(tmp_path):
+    import json
+
+    out = tmp_path / "sub" / "prd.json"
+    stories = [{"id": "STORY-001", "title": "t"}]
+    g._write_prd_json(out, "Proj", "desc", "PRD.md", stories)  # type: ignore[arg-type]
+    data = json.loads(out.read_text())
+    assert data["project"] == "Proj"
+    assert data["description"] == "desc"
+    assert data["source"] == "PRD.md"
+    assert "generated" in data
+    assert data["stories"] == stories


### PR DESCRIPTION
## What

Behavior-preserving refactor of `ralph/scripts/generate_prd_json.py` to cut complexity (was 795 LOC, 27.67 LOC/method, top fns: main 62, resolve_stories 51, _backfill 43).

Extractions:
- `main`: write block -> `_write_prd_json`; declared-count check -> `_check_declared_story_count`
- `_backfill_existing_stories` -> `_migrate_legacy_passes` + `_fill_missing_fields`
- `resolve_stories` dotted-ID logic -> `_lookup_feature` + `_resolve_sub_or_fallback`

## Strict TDD

1. Added **characterization tests** (new file `ralph/scripts/tests/test_generate_prd_json.py`) pinning current behavior — committed green first.
2. Refactored under green.
3. Added unit tests for the new helpers.

**21/21 pass**; ruff clean. **No existing tests modified.** No behavior change (same CLI, same prd.json schema/output).

Tests run via `uv run --no-project --with pytest pytest ralph/scripts/tests/test_generate_prd_json.py` (the template `pyproject.toml` has intentional placeholders, so an isolated env is used; the module is stdlib-only).

Generated with Claude <noreply@anthropic.com>