### PR TITLE
ci(codeql): add pull_request trigger so PRs satisfy merge protection

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -4,9 +4,17 @@ name: "CodeQL"
 
 on:
   push:
+  pull_request:
   schedule:
     - cron: '27 11 * * 0'
   workflow_dispatch:
+
+# Reason: pull_request trigger lets CodeQL report on the PR merge-ref that branch
+# protection waits for (push-only left some PRs BLOCKED). cancel-in-progress
+# tames the merge-ref-SHA churn the push-only variant was avoiding.
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   analyze:


### PR DESCRIPTION
## Problem

Push-only CodeQL reports on the head SHA, but branch protection waits for a CodeQL result on the **PR merge-ref**. That left some PRs (e.g. #60) `BLOCKED` with every check green.

## Fix

- Add a `pull_request` trigger so CodeQL also reports on the merge-ref.
- Add `concurrency: cancel-in-progress` to tame the merge-ref-SHA churn that the push-only variant was deliberately avoiding.

Matches the `qte77/gha-sec-feed` exemplar (push + pull_request + concurrency), vs the `analyze-stock-kpi` push-only variant which instead relies on the ruleset's `do_not_enforce_on_create: true`.

## Self-test

This PR is itself the proof: if the `pull_request`-triggered CodeQL reports and the PR goes mergeable, the fix works and unblocks #60 + future PRs.

Generated with Claude <noreply@anthropic.com>