### PR TITLE
feat(agents): AGENTS.md-only standard — symlink, skills path, seeded settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,3 @@
+{
+  "enabledPlugins": {}
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ see `CONTRIBUTING.md`.
 When working on this project, agents must:
 
 1. **Use Ralph Loop skills** - Leverage specialized skills from
-   `.claude/skills/` for phase planning, implementation, and review tasks
+   `.agents/skills/` for phase planning, implementation, and review tasks
 
 ### Quality Thresholds
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,1 @@
-# Insertions
-
-@AGENTS.md
+AGENTS.md


### PR DESCRIPTION
## Summary

- `CLAUDE.md`: replace `@AGENTS.md` stub with symlink to `AGENTS.md`
- `AGENTS.md`: update skills path reference from `.claude/skills/` to `.agents/skills/` (cross-tool canonical path)
- `.claude/settings.json`: create with seeded `enabledPlugins: {}` (prevents known bug where absent key ignores plugins)

## Test plan

- [ ] Confirm `CLAUDE.md` is a symlink: `file CLAUDE.md`
- [ ] Confirm `.claude/settings.json` is valid JSON with `enabledPlugins` key
- [ ] Confirm `AGENTS.md` references `.agents/skills/`

Generated with Claude <noreply@anthropic.com>