### PR TITLE
chore: estate-standardize .claude config (marketplace + rules sync)

### DIFF
--- a/.claude/rules/compound-learning.md
+++ b/.claude/rules/compound-learning.md
@@ -1,0 +1,35 @@
+# Compound Learning
+
+Prevent repeated mistakes by systematically promoting learnings.
+
+## Before Solving a Problem
+
+Check AGENT_LEARNINGS.md for prior art. If a matching pattern exists, apply it.
+
+## Promotion Path
+
+1. **1st occurrence** — fix inline, move on
+2. **2nd occurrence** — add to AGENT_LEARNINGS.md (pattern + solution)
+3. **3rd occurrence** — promote to a plugin's `rules/` in `claude-code-plugins`,
+   bump the plugin version, and ship via PR. Consumers receive the rule on next
+   plugin update.
+4. **Recurring workflow** — extract to a plugin's `skills/` (reusable capability)
+
+## When Promoting (step 3)
+
+- Verify the root cause is the same across occurrences
+- Write the rule as a constraint ("do X", "never Y"), not a narrative
+- Reference the AGENT_LEARNINGS.md entry being promoted
+- Remove or link the original entry to avoid duplication
+- **Choose host plugin**: pick the existing plugin whose domain matches the
+  rule; if none fits, create a minimal plugin (see `plugins/planning/` as
+  scaffold)
+- **Bump version**: update `version` in both
+  `plugins/<name>/.claude-plugin/plugin.json` and
+  `.claude-plugin/marketplace.json` — both must match
+- **Sync shared rules**: if the rule belongs in the cross-cutting
+  `.claude/rules/` set, run `make sync` to propagate copies into
+  `workspace-setup` and `workspace-sandbox`, then bump those plugins' versions
+- **Cross-repo workflow**: when the learning surfaces in a consumer repo
+  (qte77/qte77, polyforge, office-forge, etc.), open the promotion PR against
+  `claude-code-plugins`, not against the consumer

--- a/.claude/rules/core-principles.md
+++ b/.claude/rules/core-principles.md
@@ -1,41 +1,31 @@
 # Core Principles
 
 **MANDATORY for ALL tasks.** These principles override all other guidance when
-conflicts arise.
+conflicts arise. Every decision optimizes for user value, clarity, and usability.
 
-## User-Centric Principles
+## Code Quality
 
-**User Experience, User Joy, User Success** - Every decision optimizes for
-user value, clarity, and usability.
+- **KISS (Keep It Simple, Stupid)** — simplest solution that works.
+- **DRY (Don't Repeat Yourself)** — single source of truth; reference, don't duplicate.
+- **AHA (Avoid Hasty Abstractions)** — three similar lines beats a premature abstraction; extract only when the pattern is stable.
+- **YAGNI (You Aren't Gonna Need It)** — build for the requested behavior, not for imagined future ones.
 
-## Code Quality Principles
+## Execution
 
-**KISS (Keep It Simple, Stupid)** - Simplest solution that works. Clear > clever.
+- **Reuse and extend** — use existing patterns and dependencies; extend rather than rebuild.
+- **Consistency and coherence** — validate changes against established conventions; spot inconsistencies before they compound.
+- **Concise and focused** — minimal code/text for the task; touch only task-related code.
+- **Root-cause and first-principles** — solve root problems, not symptoms; understand the "why" before patching.
 
-**DRY (Don't Repeat Yourself)** - Single source of truth. Reference, don't duplicate.
+## Decision
 
-**YAGNI (You Aren't Gonna Need It)** - Implement only what's requested. No
-speculative features.
+- **Rigor and sufficiency** — research enough to decide with confidence, then move.
+- **High-impact quick wins** — prioritize must-do tasks; ship fast, iterate.
 
-## Execution Principles
+## Communication
 
-**Concise and Focused** - Minimal code/text for task. Touch only task-related code.
-
-**Reuse and Extend** - Use existing patterns and dependencies. Don't rebuild.
-
-**Prevent Incoherence** - Spot inconsistencies. Validate against existing patterns.
-
-**Resolve Ambiguity** - Clarify vague requirements before acting.
-
-## Decision Principles
-
-**Rigor and Sufficiency** - Research enough to decide confidently. No more, no less.
-
-**High-Impact Quick Wins** - Prioritize must-do tasks. Ship fast, iterate.
-
-**Actionable and Concrete** - Specific deliverables. Measurable outcomes.
-
-**Root-Cause and First-Principles** - Understand the "why". Solve root problems.
+- **Clarity** — name things for what they are; state decisions and reasons plainly; prefer concrete examples over abstract framing.
+- **Actionable and concrete** — specific deliverables, measurable outcomes.
 
 ## Before Starting Any Task
 
@@ -45,14 +35,15 @@ speculative features.
 - [ ] Do I actually need this?
 - [ ] Am I touching only relevant code?
 - [ ] What's the root cause I'm solving?
+- [ ] Is this clear to a reader who lacks my context?
 
 ## Post-Task Review
 
 Before finishing, ask yourself:
 
-- **Did we forget anything?** - Check requirements thoroughly
-- **High-ROI enhancements?** - Suggest opportunities (don't implement)
-- **Something to delete?** - Remove obsolete/unnecessary code
+- **Did we forget anything?** — check requirements thoroughly
+- **High-ROI enhancements?** — suggest opportunities (don't implement)
+- **Something to delete?** — remove obsolete/unnecessary code
 
 **IMPORTANT**: Do NOT alter files based on this review. Only output
 suggestions to the user.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,3 +1,15 @@
 {
-  "enabledPlugins": {}
+  "enabledPlugins": {},
+  "extraKnownMarketplaces": {
+    "qte77-claude-code-plugins": {
+      "source": {
+        "source": "github",
+        "repo": "qte77/claude-code-plugins"
+      }
+    }
+  },
+  "attribution": {
+    "commit": "Co-Authored-By: Claude <noreply@anthropic.com>",
+    "pr": "Generated with Claude <noreply@anthropic.com>"
+  }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 # Scaffold adapter scripts (deployed by plugins)
 .scaffolds/
 
+# Claude Code local permission grants (never commit)
+.claude/settings.local.json
+
 # Python bytecode
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
Estate-standardization sweep for the active template (matches coding-agent-eval / multi-tasking-quality-benchmark). Scoped narrowly to keep the template's lean intent; does not touch CLAUDE.md/AGENTS.md (already correct), scripts/, codeql.yaml, CHANGELOG.md, or the vibe-kanban / devcontainer / Makefile.embedded surfaces.

Changes:
- .claude/settings.json: keep it lean (enabledPlugins stays empty so generated projects opt in), add the canonical qte77-claude-code-plugins marketplace and emoji-free attribution.
- .claude/rules/: add compound-learning.md and resync core-principles.md to the workspace-setup source of truth (adds AHA, the Communication/Clarity principle, and the "is this clear" pre-task check). All three rules are now byte-identical to SoT.
- Gitignore .claude/settings.local.json (local grants must never be committed).

Intentionally kept / deferred:
- .github/workflows/codeql.yaml is unchanged: its pull_request trigger is a documented BLOCKED-PR fix, kept as an estate exception (tracker issue to follow).
- Deferred to tracker issues: ruff-ruleset expansion (template-wide, touches every generated project) and scriv changelog migration.

Does not interact with open PR #28 (compound-learning aggregation feature).

Generated with Claude <noreply@anthropic.com>