### PR TITLE
docs: README canon, AGENTS Conventions, CodeQL exception note

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -9,9 +9,15 @@ on:
     - cron: '27 11 * * 0'
   workflow_dispatch:
 
-# Reason: pull_request trigger lets CodeQL report on the PR merge-ref that branch
-# protection waits for (push-only left some PRs BLOCKED). cancel-in-progress
-# tames the merge-ref-SHA churn the push-only variant was avoiding.
+# --- Estate exception: pull_request trigger is DELIBERATE and sanctioned ---
+# Standard estate policy runs CodeQL on push only. This repo adds pull_request
+# because branch protection requires a passing CodeQL status on the PR
+# merge-ref, and push-only CodeQL runs against the branch HEAD — a different
+# SHA — leaving those status checks permanently BLOCKED on inbound PRs.
+# Adding pull_request fixes the status-check gap. The concurrency group below
+# (cancel-in-progress: true) tames the merge-ref-SHA churn that the push-only
+# variant was originally designed to avoid.
+# -------------------------------------------------------------------------
 concurrency:
   group: codeql-${{ github.ref }}
   cancel-in-progress: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,3 +64,9 @@ Agents MUST NOT:
 3. **Update ralph/LEARNINGS.md** - Document discoveries and patterns
 4. **Follow existing patterns** - Study `src/` before implementing
 5. **Reference file:line** - Always cite evidence for claims
+
+## Conventions
+
+- Agent config is AGENTS.md-only; CLAUDE.md is a symlink to this file.
+- Claude Code plugins are configured in .claude/settings.json against the
+  qte77-claude-code-plugins marketplace; shared rules live in .claude/rules/.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Standardized .claude (marketplace qte77-claude-code-plugins, estate rules incl. compound-learning, attribution); README to doc-structure canon; AGENTS.md Conventions section; documented the CodeQL pull_request-trigger estate exception.
 - `ralph_run`, `ralph_init_and_run`: added TIMEOUT, MODEL, TEAMS, DRY_RUN, INSTRUCTION, DESLOPIFY pass-through params
 - Removed unused `RALPH_TEAMS` env var passthrough from Makefile recipes (only `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` matters downstream)
 - `ralph_run_worktree`: expanded from worktree-only to full run-in-worktree with all params

--- a/README.md
+++ b/README.md
@@ -2,194 +2,64 @@
 
 > What a time to be alive
 
-Language-agnostic project template using Ralph Loop autonomous development with plugin-based scaffold architecture
+Ship a TDD + Ralph-loop + Vibe-Kanban agent harness without writing boilerplate.
 
 **Write-up:** the autonomous loop at the center of an open agentic coding harness — [An Open Agentic Coding Harness](https://qte77.github.io/open-agentic-coding-harness/).
 
 ![Version](https://img.shields.io/badge/version-0.0.0-58f4c2.svg)
 [![License](https://img.shields.io/badge/license-Apache--2.0-58f4c2.svg)](LICENSE)
-[![CodeQL](https://github.com/YOUR-ORG/YOUR-PROJECT-NAME/actions/workflows/codeql.yaml/badge.svg)](https://github.com/YOUR-ORG/YOUR-PROJECT-NAME/actions/workflows/codeql.yaml)
-[![CodeFactor](https://www.codefactor.io/repository/github/YOUR-ORG/YOUR-PROJECT-NAME/badge)](https://www.codefactor.io/repository/github/YOUR-ORG/YOUR-PROJECT-NAME)
-[![ruff](https://github.com/YOUR-ORG/YOUR-PROJECT-NAME/actions/workflows/ruff.yaml/badge.svg)](https://github.com/YOUR-ORG/YOUR-PROJECT-NAME/actions/workflows/ruff.yaml)
-[![pyright](https://github.com/YOUR-ORG/YOUR-PROJECT-NAME/actions/workflows/pyright.yaml/badge.svg)](https://github.com/YOUR-ORG/YOUR-PROJECT-NAME/actions/workflows/pyright.yaml)
-[![pytest](https://github.com/YOUR-ORG/YOUR-PROJECT-NAME/actions/workflows/pytest.yaml/badge.svg)](https://github.com/YOUR-ORG/YOUR-PROJECT-NAME/actions/workflows/pytest.yaml)
-[![Link Checker](https://github.com/YOUR-ORG/YOUR-PROJECT-NAME/actions/workflows/links-fail-fast.yaml/badge.svg)](https://github.com/YOUR-ORG/YOUR-PROJECT-NAME/actions/workflows/links-fail-fast.yaml)
-[![Deploy Docs](https://github.com/YOUR-ORG/YOUR-PROJECT-NAME/actions/workflows/generate-deploy-mkdocs-ghpages.yaml/badge.svg)](https://github.com/YOUR-ORG/YOUR-PROJECT-NAME/actions/workflows/generate-deploy-mkdocs-ghpages.yaml)
+[![CodeQL](https://github.com/qte77/ralph-loop-cc-tdd-wt-vibe-kanban-template/actions/workflows/codeql.yaml/badge.svg)](https://github.com/qte77/ralph-loop-cc-tdd-wt-vibe-kanban-template/actions/workflows/codeql.yaml)
+[![CodeFactor](https://www.codefactor.io/repository/github/qte77/ralph-loop-cc-tdd-wt-vibe-kanban-template/badge)](https://www.codefactor.io/repository/github/qte77/ralph-loop-cc-tdd-wt-vibe-kanban-template)
+[![ruff](https://github.com/qte77/ralph-loop-cc-tdd-wt-vibe-kanban-template/actions/workflows/ruff.yaml/badge.svg)](https://github.com/qte77/ralph-loop-cc-tdd-wt-vibe-kanban-template/actions/workflows/ruff.yaml)
+[![pyright](https://github.com/qte77/ralph-loop-cc-tdd-wt-vibe-kanban-template/actions/workflows/pyright.yaml/badge.svg)](https://github.com/qte77/ralph-loop-cc-tdd-wt-vibe-kanban-template/actions/workflows/pyright.yaml)
+[![pytest](https://github.com/qte77/ralph-loop-cc-tdd-wt-vibe-kanban-template/actions/workflows/pytest.yaml/badge.svg)](https://github.com/qte77/ralph-loop-cc-tdd-wt-vibe-kanban-template/actions/workflows/pytest.yaml)
+[![Link Checker](https://github.com/qte77/ralph-loop-cc-tdd-wt-vibe-kanban-template/actions/workflows/links-fail-fast.yaml/badge.svg)](https://github.com/qte77/ralph-loop-cc-tdd-wt-vibe-kanban-template/actions/workflows/links-fail-fast.yaml)
+[![Deploy Docs](https://github.com/qte77/ralph-loop-cc-tdd-wt-vibe-kanban-template/actions/workflows/generate-deploy-mkdocs-ghpages.yaml/badge.svg)](https://github.com/qte77/ralph-loop-cc-tdd-wt-vibe-kanban-template/actions/workflows/generate-deploy-mkdocs-ghpages.yaml)
 
-## Features
+## What
 
-- **Ralph Loop** - Autonomous development using a shell loop
-- **Claude Code** - Pre-configured skills, plugins, rules, and commands for
-  AI-assisted development
-- **Plugin-based Scaffold** - Language-agnostic core; language toolchain installed
-  on demand via `make setup_scaffold LANG=<lang>`
-- **Makefile** - Split architecture: core recipes in `Makefile`,
-  language-specific recipes in `Makefile.<lang>` (auto-included from `.scaffold`)
+- **Ralph Loop** - Autonomous agent development via a shell loop; write requirements, let Ralph implement
+- **Claude Code** - Pre-configured skills, rules, plugins, and model routing for AI-assisted development
+- **Language-agnostic scaffold** - Python, embedded C, and TypeScript toolchains installed on demand
+- **GitHub Actions CI/CD** - CodeQL, ruff, pyright, pytest, link checking, and docs deployment wired up
 - **MkDocs** - Auto-generated documentation with GitHub Pages deployment
-- **GitHub Actions** - CI/CD workflows (CodeQL, ruff, pyright, pytest, link
-  checking, docs deployment)
-- **DevContainers** - Template (Alpine ~10MB) and actual project
-  (Python/Node/Docker ~1GB+)
-- **VS Code** - Workspace settings, tasks, and extensions for development
-- **Configurable Model routing** - Use different models for hard or easy tasks.
-  See [Ralph README.md](./ralph/README.md#configuration).
+- **DevContainers** - Template (Alpine ~10MB) and project (Python/Node/Docker ~1GB+) variants
+- **Vibe Kanban** - Real-time visual monitoring for Ralph task progress
 
-## Scaffold Workflow
-
-The scaffold system writes a `.scaffold` file (gitignored) that controls which
-`Makefile.<lang>` is auto-included at build time:
-
-```bash
-# Initialize scaffold for your language (run once after cloning)
-make setup_scaffold LANG=python     # Python: ruff, pyright, pytest, mkdocs
-make setup_scaffold LANG=embedded   # Embedded C: cmake build + flash
-
-# Install the toolchain for the active scaffold
-make setup_toolchain
-
-# Validate — dispatches to the active scaffold's validate recipe
-make validate
-```
-
-Supported languages:
-
-| `LANG` | Toolchain | Validate |
-|--------|-----------|---------|
-| `python` | uv, ruff, pyright, pytest | ruff + pyright + complexipy + pytest |
-| `embedded` | cmake, C compiler | cmake build |
-| `typescript` | node, npm, eslint, tsc, vitest | eslint + tsc + vitest |
-
-Language-specific Claude Code skills are **not** checked into the template.
-Install them from [claude-code-plugins](https://github.com/qte77/claude-code-plugins)
-as needed for your language.
-
-## Quick Start
+## How
 
 ```bash
 # 1. Choose your language scaffold (written to .scaffold, gitignored)
 make setup_scaffold LANG=python
 
-# 2. Install toolchain (also runs automatically in devcontainer via onCreateCommand)
+# 2. Install toolchain (also runs automatically in devcontainer)
 make setup_toolchain
 
-# 3. Customize template with your project details
-make setup_project
-
-# Optional
-make ralph_create_userstory_md            # Interactive User Story using CC
-make ralph_create_prd_md                  # Generate PRD.md from UserStory.md
-
-# 4. Write requirements in docs/PRD.md, then run Ralph
+# 3. Write requirements in docs/PRD.md, then run Ralph
 make ralph_init_loop             # Initialize (creates prd.json)
 make ralph_run [ITERATIONS=25]   # Run autonomous development
-make ralph_run                   # Resume if paused (auto-detects existing worktrees)
-make ralph_status                # Check progress (with timestamp)
-
-# 5. Post-run options
-# Reset state (removes prd.json, progress.txt)
-make ralph_clean
-# Archive and start new iteration
-make ralph_archive NEW_PRD=docs/PRD-v2.md [VERSION=2]
 ```
 
-For detailed setup and usage, see
-[docs/TEMPLATE_USAGE.md](docs/TEMPLATE_USAGE.md). For Ralph Loop details see
-[Ralph README.md](./ralph/README.md).
+For DevContainer sizes, Makefile details, submodule consumption, advanced Ralph
+options, and Vibe Kanban setup, see
+[docs/TEMPLATE_USAGE.md](docs/TEMPLATE_USAGE.md).
 
-## Workflow
+## Why
 
-```text
-Document Flow:
-  UserStory.md (Why) → PRD.md (What) → prd.json → Implementation → progress.txt
+Hand-rolling an agent-loop setup per project wastes hours on boilerplate. The
+incumbent approach requires assembling TDD harnesses, agent config, CI pipelines,
+and kanban tooling from scratch for every new project. This template ships the
+complete Ralph-loop + TDD + Vibe-Kanban stack ready to go: clone, write a PRD,
+run Ralph.
 
-Human Workflow (Manual):
-  Write PRD.md → make ralph_init_loop → make ralph
+## References
 
-Human Workflow (Assisted - Optional):
-  make ralph_create_userstory_md → make ralph_create_prd_md → make ralph_init_loop → make ralph
+- [Ralph README](./ralph/README.md)
+- [docs/TEMPLATE_USAGE.md](docs/TEMPLATE_USAGE.md)
+- [qte77/claude-code-plugins](https://github.com/qte77/claude-code-plugins)
+- [An Open Agentic Coding Harness](https://qte77.github.io/open-agentic-coding-harness/)
+- [CONTRIBUTING.md](CONTRIBUTING.md)
 
-Agent Workflow:
-  PRD.md → prd.json (generating-prd-json-from-prd-md skill) → Ralph Loop → src/ + tests/
-  Uses: .claude/skills/, .claude/rules/
+## License
 
-Mandatory for Both:
-  CONTRIBUTING.md - Core principles (KISS, DRY, YAGNI)
-  Makefile        - Build automation and validation
-  .gitmessage     - Commit message format
-```
-
-## Consumption Approaches
-
-### 1. GitHub Template (default)
-
-Use "Use this template" on GitHub. Full project scaffold with `ralph/`,
-`.claude/`, CI workflows, devcontainer, etc.
-
-### 2. Git Submodule (existing project)
-
-Add Ralph as a submodule at `ralph/`. Scripts update automatically
-via `git submodule update --remote`. Local state files (`prd.json`,
-`progress.txt`, `LEARNINGS.md`, `archive/`) are gitignored in the
-template so they survive updates.
-
-```bash
-# Add submodule
-git submodule add --branch main \
-  https://github.com/qte77/ralph-loop-cc-tdd-wt-vibe-kanban-template.git \
-  ralph
-
-# Initialize local state files (gitignored, never overwritten)
-cp ralph/LEARNINGS.md.example ralph/LEARNINGS.md
-cp ralph/REQUESTS.md.example ralph/REQUESTS.md
-mkdir -p ralph/docs/archive
-
-# Include ralph's Makefile from your project root Makefile
-echo '-include ralph/Makefile' >> Makefile
-
-# Ignore dirty submodule state (local files)
-git config -f .gitmodules submodule.ralph.ignore dirty
-```
-
-**Update:**
-
-```bash
-git submodule update --remote ralph
-git add ralph
-git commit -m "chore: update ralph submodule"
-```
-
-**Makefile integration:** Ralph ships a scoped `Makefile` with all
-`ralph_*` recipes using relative paths. Include it from your
-project root:
-
-```makefile
-# Project root Makefile
--include ralph/Makefile
-```
-
-**CI (required):** Add `submodules: recursive` to all
-`actions/checkout` steps. Without this, CI clones the repo but
-leaves `ralph/` empty — any workflow running `make validate`,
-`make test`, or ralph commands will fail.
-
-```yaml
-- uses: actions/checkout@v4
-  with:
-    submodules: recursive
-```
-
-**`.claude/`** can be symlinked (read-only) or copied (overrides).
-Claude Code merges `.claude/settings.local.json` over
-`.claude/settings.json`.
-
-### 3. Standalone CLI (planned)
-
-Install Ralph as a standalone binary. No git integration needed.
-Candidates: Go (static binary, zero deps), Bun/Deno (scripting feel +
-native JSON). See [Ralph README.md TODO](./ralph/README.md#todo--future-work)
-for scope analysis.
-
-## Contributing
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for development workflow, core
-principles, and contribution guidelines.
+Apache-2.0 - see [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -10,11 +10,6 @@ Ship a TDD + Ralph-loop + Vibe-Kanban agent harness without writing boilerplate.
 [![License](https://img.shields.io/badge/license-Apache--2.0-58f4c2.svg)](LICENSE)
 [![CodeQL](https://github.com/qte77/ralph-loop-cc-tdd-wt-vibe-kanban-template/actions/workflows/codeql.yaml/badge.svg)](https://github.com/qte77/ralph-loop-cc-tdd-wt-vibe-kanban-template/actions/workflows/codeql.yaml)
 [![CodeFactor](https://www.codefactor.io/repository/github/qte77/ralph-loop-cc-tdd-wt-vibe-kanban-template/badge)](https://www.codefactor.io/repository/github/qte77/ralph-loop-cc-tdd-wt-vibe-kanban-template)
-[![ruff](https://github.com/qte77/ralph-loop-cc-tdd-wt-vibe-kanban-template/actions/workflows/ruff.yaml/badge.svg)](https://github.com/qte77/ralph-loop-cc-tdd-wt-vibe-kanban-template/actions/workflows/ruff.yaml)
-[![pyright](https://github.com/qte77/ralph-loop-cc-tdd-wt-vibe-kanban-template/actions/workflows/pyright.yaml/badge.svg)](https://github.com/qte77/ralph-loop-cc-tdd-wt-vibe-kanban-template/actions/workflows/pyright.yaml)
-[![pytest](https://github.com/qte77/ralph-loop-cc-tdd-wt-vibe-kanban-template/actions/workflows/pytest.yaml/badge.svg)](https://github.com/qte77/ralph-loop-cc-tdd-wt-vibe-kanban-template/actions/workflows/pytest.yaml)
-[![Link Checker](https://github.com/qte77/ralph-loop-cc-tdd-wt-vibe-kanban-template/actions/workflows/links-fail-fast.yaml/badge.svg)](https://github.com/qte77/ralph-loop-cc-tdd-wt-vibe-kanban-template/actions/workflows/links-fail-fast.yaml)
-[![Deploy Docs](https://github.com/qte77/ralph-loop-cc-tdd-wt-vibe-kanban-template/actions/workflows/generate-deploy-mkdocs-ghpages.yaml/badge.svg)](https://github.com/qte77/ralph-loop-cc-tdd-wt-vibe-kanban-template/actions/workflows/generate-deploy-mkdocs-ghpages.yaml)
 
 ## What
 

--- a/docs/TEMPLATE_USAGE.md
+++ b/docs/TEMPLATE_USAGE.md
@@ -59,10 +59,20 @@ make ralph_archive NEW_PRD=docs/PRD-v2.md VERSION=2
 Archives current PRD, prd.json, and progress to `ralph/docs/archive/`, then
 activates new PRD.
 
+## Substitutions Required After Generating From This Template
+
+After clicking "Use this template" on GitHub, update the following placeholders:
+
+- `mkdocs.yaml` — replace `[PROJECT NAME]`, `[PROJECT DESCRIPTION]`, and
+  `[GITHUB REPO]` with your project values.
+- `README.md` badges — replace `qte77/ralph-loop-cc-tdd-wt-vibe-kanban-template`
+  with your org/repo slug in every badge URL.
+
 ## Optional: MCP Servers
 
-Template includes `context7` and `exa` MCP servers. Remove from
-`.claude/settings.json` if not needed.
+The `.claude/settings.json` uses the qte77-claude-code-plugins marketplace with
+an empty `enabledPlugins` list by default. Add or enable plugins as needed for
+your language or workflow; there are no MCP servers bundled with this template.
 
 ## Optional: Vibe Kanban UI
 


### PR DESCRIPTION
Rewrites README to the estate doc-structure canon (#82): adds Why, trims What, collapses How, adds Refs + License, and fixes the placeholder badge URLs (subsumes the closed #43). Adds the standard Conventions section to AGENTS.md (only repo missing it), fixes the stale MCP-servers line in TEMPLATE_USAGE.md and documents required template substitutions, and documents the CodeQL pull_request-trigger estate exception in codeql.yaml (#80). Does not touch open PR #28.

Closes #82. Closes #80.

Generated with Claude <noreply@anthropic.com>